### PR TITLE
ダブルクォーテーションが記号になっているのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ result
 ```html
 <title>Example Title | Svelte Head Demo</title>
 <meta name="description" content="svelte-head is a component library that allows you to easily set meta information etc. to be output to head.">
-<meta name="”keywords”" content="svelte,sveltekit,seo,head,meta">
+<meta name="keywords" content="svelte,sveltekit,seo,head,meta">
 <meta property="og:title" content="Example Title | Svelte Head Demo">
 <meta property="og:description" content="svelte-head is a component library that allows you to easily set meta information etc. to be output to head.">
 <meta property="og:type" content="website">

--- a/src/lib/Meta.svelte
+++ b/src/lib/Meta.svelte
@@ -22,13 +22,13 @@
   <!-- SEO -->
   <title>{_title}</title>
   <meta name="description" content="{_description}" />
-  <meta name=”keywords” content={_keywords} />
+  <meta name="keywords" content={_keywords} />
 
   {#if _noindex}
-    <meta name=”robots” content=”noindex”>
+    <meta name="robots" content="noindex">
   {/if}
   {#if _nofollow}
-    <meta name=”robots” content=”nofollow”>
+    <meta name="robots" content="nofollow">
   {/if}
 
   <!-- OGP -->


### PR DESCRIPTION
ダブルクォーテーションが `”` という記号になっているのを `"` に修正しました。

レンダリング時に以下のようになっていて正しくmetaが設定できていない問題を修正
`name="”keywords”"`
`<meta name="”robots”" content="”noindex”">`